### PR TITLE
Extended methods for getting shared link of a file

### DIFF
--- a/grails-app/services/com/dropbox/core/DropBoxService.groovy
+++ b/grails-app/services/com/dropbox/core/DropBoxService.groovy
@@ -57,4 +57,9 @@ class DropBoxService extends AbstractDropBoxService {
         String bodyArgs = encodeParams([root: root, from_path: fromPath, to_path: toPath])
         return post('/fileops/move', bodyArgs, accessToken)
     }
+
+    /* creates link for sharing a file or returns a share link if existing. */
+    String shares(String path, accessToken) {
+        return get("/shares/auto/${path}", accessToken)
+    }
 }


### PR DESCRIPTION
Hey,
this is my first fork and pull request ever, I hope I am doing this right. I extended the DropBoxService for a method to create a share link (or get the link if it already exist) from DropBox. It can be used to publish files.

Usage could be e.g.:
def jsonResponse = dropBoxService.shares('pizza.jpg', dropBoxAccessToken)
def slurper = new JsonSlurper()
def result = slurper.parseText(jsonResponse)
def url = result.url

But this only gets the shurt_url. But I need to get the long url so that I can receive the raw image by adding "&raw=1" to the shared link. Is there a way I can add params to your methods? See https://www.dropbox.com/developers-v1/core/docs#shares for "short_url".

Thanks