### PR TITLE
Modified some methods to accept paramaters map instead of token string…

### DIFF
--- a/DropBoxGrailsPlugin.groovy
+++ b/DropBoxGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 class DropBoxGrailsPlugin {
-    def version = '1.3.1'
+    def version = '1.3.1a'
     def grailsVersion = '2.0 > *'
     def title = 'Drop Box Plugin for Grails'
     def description = 'Adds integration with the DropBox API. Here with this plugin you can use all DropBox services within from your Grails application'

--- a/grails-app/services/com/dropbox/core/DropBoxService.groovy
+++ b/grails-app/services/com/dropbox/core/DropBoxService.groovy
@@ -13,7 +13,7 @@ class DropBoxService extends AbstractDropBoxService {
     static transactional = false
 
     String accountInfo(String accessToken) {
-        String response = get('/account/info', accessToken)
+        String response = get('/account/info', [access_token: accessToken])
         JSONElement contents = JSON.parse(response)
         String displayName = contents.display_name
         String email = contents.email
@@ -24,7 +24,7 @@ class DropBoxService extends AbstractDropBoxService {
     String dropBoxFileUpload(String root, String destinationPath, byte[] data, String mimeType, String accessToken) {
         HttpURLConnection connection
         try {
-            URL url = new URL("https://api-content.dropbox.com/1/files_put/${root}/${destinationPath}${toQueryString(accessToken)}")
+            URL url = new URL("https://api-content.dropbox.com/1/files_put/${root}/${destinationPath}${encodeParams([access_token: accessToken])}")
             connection = createOutputConnection(url, 'PUT', mimeType, data.length)
             write connection, data
             return read(connection)
@@ -35,7 +35,7 @@ class DropBoxService extends AbstractDropBoxService {
     }
 
     String getObjectMetaData(String root, String path, String accessToken) {
-        return get("/metadata/${root}/${path}", accessToken)
+        return get("/metadata/${root}/${path}", [access_token: accessToken])
     }
 
     String createNewFolder(String root, String path, String accessToken) {
@@ -59,7 +59,7 @@ class DropBoxService extends AbstractDropBoxService {
     }
 
     /* creates link for sharing a file or returns a share link if existing. */
-    String shares(String path, accessToken) {
-        return get("/shares/auto/${path}", accessToken)
+    String shares(String path, Map params) {
+        return get("/shares/auto/${path}", params)
     }
 }

--- a/src/groovy/grails/plugin/dropbox/AbstractDropBoxService.groovy
+++ b/src/groovy/grails/plugin/dropbox/AbstractDropBoxService.groovy
@@ -4,12 +4,12 @@ abstract class AbstractDropBoxService {
 
     static final String URL_ROOT = 'https://api.dropbox.com/1'
 
-    protected String get(String uri, String accessToken) {
-        return new URL("${URL_ROOT}${uri}${toQueryString(accessToken)}").text
+    protected String get(String uri, Map params) {
+        return new URL("${URL_ROOT}${uri}?${encodeParams(params)}").text
     }
 
     protected post(String uri, String body, String accessToken) {
-        URL url = new URL("${URL_ROOT}${uri}${toQueryString(accessToken)}")
+        URL url = new URL("${URL_ROOT}${uri}?${encodeParams([access_token: accessToken])}")
         HttpURLConnection connection
         try {
             connection = createOutputConnection(url, 'POST', 'application/x-www-form-urlencoded', body.length())
@@ -45,10 +45,6 @@ abstract class AbstractDropBoxService {
 
     protected String read(HttpURLConnection connection) {
         return new InputStreamReader(connection.inputStream).text
-    }
-
-    protected String toQueryString(String accessToken) {
-        return accessToken ? ('?' + encodeParams([access_token: accessToken])) : ''
     }
 
     protected String encodeParams(Map params) {


### PR DESCRIPTION
With this changes the shares method accepts a paramters Map. Other methods were adapted to work as before by writing the token String into a Map.

Please test this first before merging (no hurry). I still have several problems including the plugin to maven and to add and install it to my local app as dependency for testing. So I could not test it completely yet. 
